### PR TITLE
App locations csv

### DIFF
--- a/tdprocessor.py
+++ b/tdprocessor.py
@@ -146,7 +146,7 @@ def write_app_locations():
   # creating a list of rows to write to the csv
   for path in path_list:
       head_tail = os.path.split(path)
-      task_name = head_tail[1].split(".")[0]
+      task_name = head_tail[1].split(".")[0].lower()
       write_list.append([task_name, path, "Program Added"])
   
   # Creating app_link csv

--- a/tdprocessor.py
+++ b/tdprocessor.py
@@ -134,7 +134,7 @@ def write_app_locations():
   '''
   path_list = get_app_locations()
   write_list = []
-  
+
   # create .harvidata directory
   try:
       # os.chdir(f"c:\\users\\{username}")
@@ -143,7 +143,7 @@ def write_app_locations():
   except FileExistsError:
       pass
 
-  # creates a list of rows to write to the csv
+  # creating a list of rows to write to the csv
   for path in path_list:
       head_tail = os.path.split(path)
       task_name = head_tail[1].split(".")[0]

--- a/tdprocessor.py
+++ b/tdprocessor.py
@@ -9,8 +9,9 @@ import pickle
 import getpass
 import win32com.client 
 
-APP_LINK_FILE = "Taskdata/applinktaskdata.csv"
-WEB_LINK_FILE = "Taskdata/weblinktaskdata.csv"
+
+APP_LINK_FILE = ".harvidata/applinktaskdata.csv"
+WEB_LINK_FILE = ".harvidata/weblinktaskdata.csv"
 
 
 try:
@@ -105,6 +106,51 @@ def file_decider(mode, operationtype):
 
 
 def get_app_locations():
+  '''
+  returns the list of all the installed programs added in the start menu
+  '''
+  link_list = []  # list of all the exe file locations
+  username = getpass.getuser()
+  shell = win32com.client.Dispatch("WScript.Shell")
+
+  DIRLIST = ['C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs',
+             f'C:\\Users\\{username}\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs']
+
+  for dirs in DIRLIST:
+      for (dirpath, dirnames, filenames) in os.walk(dirs):
+          for name in filenames:
+              if name.endswith(".lnk"):
+                  path = os.path.join(dirpath, name)
+                  shortcut = shell.CreateShortCut(path)
+                  link_list.append(shortcut.Targetpath)
+  return link_list
+
+
+def write_app_locations():
+  '''
+  void function writes all the app locations to a csv
+  '''
+  link_list = get_app_locations()
+
+  # create .harvidata directory
+  try:
+      # os.chdir(f"c:\\users\\{username}")
+      os.mkdir(".harvidata")
+      os.system('attrib +h ".harvidata"')
+  except FileExistsError:
+      pass
+  
+
+  with open(APP_LINK_FILE, "w", newline="") as taskfile:
+    twriter = csv.writer(taskfile)
+    twriter.writerow(["Name of task", "Task link", "Mode of Adding"])
+    # twriter.writerows(loclist)
+    templist = []
+  
+
+
+
+def get_app_locations_depreciated():
   username = getpass.getuser()
   try:
       # os.chdir(f"c:\\users\\{username}")

--- a/tdprocessor.py
+++ b/tdprocessor.py
@@ -109,7 +109,7 @@ def get_app_locations():
   '''
   returns the list of all the installed programs added in the start menu
   '''
-  link_list = []  # list of all the exe file locations
+  path_list = []  # list of all the exe file locations
   username = getpass.getuser()
   shell = win32com.client.Dispatch("WScript.Shell")
 
@@ -122,16 +122,19 @@ def get_app_locations():
               if name.endswith(".lnk"):
                   path = os.path.join(dirpath, name)
                   shortcut = shell.CreateShortCut(path)
-                  link_list.append(shortcut.Targetpath)
-  return link_list
+                  target_path = shortcut.Targetpath
+                  if target_path.endswith(".exe"):
+                    path_list.append(shortcut.Targetpath)
+  return path_list
 
 
 def write_app_locations():
   '''
   void function writes all the app locations to a csv
   '''
-  link_list = get_app_locations()
-
+  path_list = get_app_locations()
+  write_list = []
+  
   # create .harvidata directory
   try:
       # os.chdir(f"c:\\users\\{username}")
@@ -139,13 +142,18 @@ def write_app_locations():
       os.system('attrib +h ".harvidata"')
   except FileExistsError:
       pass
-  
 
+  # creates a list of rows to write to the csv
+  for path in path_list:
+      head_tail = os.path.split(path)
+      task_name = head_tail[1].split(".")[0]
+      write_list.append([task_name, path, "Program Added"])
+  
+  # Creating app_link csv
   with open(APP_LINK_FILE, "w", newline="") as taskfile:
     twriter = csv.writer(taskfile)
-    twriter.writerow(["Name of task", "Task link", "Mode of Adding"])
-    # twriter.writerows(loclist)
-    templist = []
+    twriter.writerow(["Name of task", "Task path", "Mode of Adding"])
+    twriter.writerows(write_list)
   
 
 


### PR DESCRIPTION
Created two new functions to get a list of all installed apps in the start menu (aka 99%) and write their locations along with names to the csv file in `.harvidata`. Old function to handle the same task was renamed from `get_app_locations` to `get_app_locations_depreciated`.  It can safely be deleted and the new function `write_app_locations()` must be called for updated efficient method to take effect